### PR TITLE
Add foreground color to window controls

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ exports.decorateConfig = config => {
 
   let windowControlsCSS;
   if (config.showWindowControls) {
-    windowControlsCSS = `.shape_1oxq { color: ${foregroundColor}; }`;
+    windowControlsCSS = `.header_shape { color: ${foregroundColor}; }`;
   }
 
   const decoratedConfig = Object.assign({}, config, {

--- a/index.js
+++ b/index.js
@@ -12,6 +12,11 @@ const lightBlack = '#696c77';
 exports.decorateConfig = config => {
   const backgroundColor = config.enableVibrancy ? 'transparent' : '#fafafa';
 
+  let windowControlsCSS;
+  if (config.showWindowControls) {
+    windowControlsCSS = `.shape_1oxq { color: ${foregroundColor}; }`;
+  }
+
   const decoratedConfig = Object.assign({}, config, {
     backgroundColor,
     foregroundColor,
@@ -96,6 +101,7 @@ exports.decorateConfig = config => {
       .tab_tab.tab_hasActivity {
         color: ${blue} !important;
       }
+      ${windowControlsCSS}
     `,
     termCSS: `
       ${config.termCSS || ''}


### PR DESCRIPTION
When you running Hyper on Windows or Linux then you have concrete controls on top of the Hyper window. Unfortunately, in the current version of this plugin the color of the action controls are white and cannot be seen:

![before_inked](https://cloud.githubusercontent.com/assets/426412/26012255/3e00c532-3754-11e7-927e-0b65d84be0f5.jpg)

For this reason, I created this pull-request to set the foreground color of the theme for this controls if the window controls are shown:

![after](https://cloud.githubusercontent.com/assets/426412/26012297/64ca7cbc-3754-11e7-8061-6df036beaa10.png)
